### PR TITLE
added two new missing rules for css formatting

### DIFF
--- a/packages/stylelint-config-leboncoin/index.js
+++ b/packages/stylelint-config-leboncoin/index.js
@@ -12,5 +12,7 @@ module.exports = {
       },
     ],
     'shorthand-property-no-redundant-values': null,
+    'block-opening-brace-space-before': 'always',
+    'declaration-colon-space-after': 'always-single-line',
   },
 }


### PR DESCRIPTION
This PR adds two new rules for css formatting:

- `block-opening-brace-space-before: 'always'`
- `declaration-colon-space-after: 'always-single-line'`

Without these two rules it was possible to have css files with inconsistent spacing:

```css
.foo{
  color:red;
  margin: 0;
}

.bar {
}
```