### PR TITLE
Add import/no-extraneous-dependencies

### DIFF
--- a/packages/eslint-config-leboncoin/index.js
+++ b/packages/eslint-config-leboncoin/index.js
@@ -23,6 +23,7 @@ module.exports = {
     'lodash',
     'sort-class-members',
     'no-constructor-bind',
+    'import',
   ],
   parser: 'babel-eslint',
   parserOptions: {
@@ -141,5 +142,6 @@ module.exports = {
     'no-constructor-bind/no-constructor-bind': 'error',
     'no-constructor-bind/no-constructor-state': 'error',
     'space-before-function-paren': 1,
+    'import/no-extraneous-dependencies': ['error'],
   },
 }


### PR DESCRIPTION
This is to prevent packages to be imported if they're not declared
anywhere:
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md

Especially useful on brikke, where devs forget to declare their import in the leaf package.json