### PR TITLE
Add prefer-rtl-namespace leboncoin rule

### DIFF
--- a/packages/eslint-plugin-leboncoin/lib/rules/prefer-rtl-namespace.js
+++ b/packages/eslint-plugin-leboncoin/lib/rules/prefer-rtl-namespace.js
@@ -1,0 +1,25 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prefer use of `rtl` namespace over `@testing-library/react` (prefer-rtl-namespace)',
+      category: 'Best practices',
+      recommended: false,
+    },
+    fixable: null,
+    schema: [],
+    type: 'problem',
+  },
+
+  create: context => ({
+    ImportDeclaration (node) {
+      const identifier = node.source.value
+
+      if (identifier !== '@testing-library/react') return
+
+      context.report(
+        node,
+        `Unexpected “${identifier}”: prefer the use of the “rtl” namespace`
+      )
+    }
+  }),
+}

--- a/packages/eslint-plugin-leboncoin/lib/rules/prefer-rtl-namespace.js
+++ b/packages/eslint-plugin-leboncoin/lib/rules/prefer-rtl-namespace.js
@@ -5,6 +5,9 @@ module.exports = {
       category: 'Best practices',
       recommended: false,
     },
+    messages: {
+      preferNamespace: 'Unexpected “{{ sourceValue }”: prefer the use of the “rtl” namespace',
+    },
     fixable: null,
     schema: [],
     type: 'problem',
@@ -12,14 +15,17 @@ module.exports = {
 
   create: context => ({
     ImportDeclaration (node) {
-      const identifier = node.source.value
+      const sourceValue = node.source.value
 
-      if (identifier !== '@testing-library/react') return
+      if (sourceValue !== '@testing-library/react') return
 
-      context.report(
+      context.report({
         node,
-        `Unexpected “${identifier}”: prefer the use of the “rtl” namespace`
-      )
+        messageId: 'preferNamespace',
+        data: {
+          sourceValue,
+        },
+      })
     }
   }),
 }

--- a/packages/eslint-plugin-leboncoin/tests/lib/rules/no-bind-constructor.js
+++ b/packages/eslint-plugin-leboncoin/tests/lib/rules/no-bind-constructor.js
@@ -3,15 +3,7 @@
 // ------------------------------------------------------------------------------
 
 const rule = require('../../../lib/rules/no-bind-constructor')
-const RuleTester = require('eslint').RuleTester
-
-RuleTester.setDefaultConfig({
-  parserOptions: {
-    ecmaVersion: 8,
-    ecmaFeatures: { experimentalObjectRestSpread: true, globalReturn: false },
-    sourceType: 'module',
-  },
-})
+const RuleTester = require('../../rule-tester')
 
 // ------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-leboncoin/tests/lib/rules/prefer-rtl-namespace.js
+++ b/packages/eslint-plugin-leboncoin/tests/lib/rules/prefer-rtl-namespace.js
@@ -1,0 +1,25 @@
+const rule = require('../../../lib/rules/prefer-rtl-namespace')
+const RuleTester = require('../../rule-tester')
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('prefer-rtl-namespace', rule, {
+  valid: [
+    `
+      import { fireEvent, render } from 'rtl'
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+        import { fireEvent, render } from '@testing-library/react'
+      `,
+      errors: [
+        {
+          message: 'Unexpected “@testing-library/react”: prefer the use of the “rtl” namespace',
+          type: 'ImportDeclaration',
+        }
+      ],
+    },
+  ]
+})

--- a/packages/eslint-plugin-leboncoin/tests/lib/rules/prefer-rtl-namespace.js
+++ b/packages/eslint-plugin-leboncoin/tests/lib/rules/prefer-rtl-namespace.js
@@ -16,7 +16,7 @@ ruleTester.run('prefer-rtl-namespace', rule, {
       `,
       errors: [
         {
-          message: 'Unexpected “@testing-library/react”: prefer the use of the “rtl” namespace',
+          messageId: 'preferNamespace',
           type: 'ImportDeclaration',
         }
       ],

--- a/packages/eslint-plugin-leboncoin/tests/rule-tester.js
+++ b/packages/eslint-plugin-leboncoin/tests/rule-tester.js
@@ -1,0 +1,14 @@
+const RuleTester = require('eslint').RuleTester
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 8,
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      globalReturn: false
+    },
+    sourceType: 'module',
+  },
+})
+
+module.exports = RuleTester


### PR DESCRIPTION
This adds a new rule for leboncoin to invite the developers to use the namespace `rtl` to import functions from Testing Library.