### PR TITLE
add eslint-plugin-literal-blacklist and configure it

### DIFF
--- a/packages/eslint-config-leboncoin/index.js
+++ b/packages/eslint-config-leboncoin/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'babel',
     'jest',
     'json',
+    'literal-blacklist',
     'lodash',
     'no-constructor-bind',
     'prefer-object-spread',
@@ -60,6 +61,15 @@ module.exports = {
     'default-case': 'error',
     'jest/valid-expect-in-promise': 'off',
     'jsx-quotes': 'error',
+    'literal-blacklist/literal-blacklist': [
+      'error',
+      // Add strings here you want to forbid in the code base.
+      // For example, if 'foo' is blacklisted, this expression will throw an error:
+      // const myVar = 'this is a foo text'
+      [
+        'datadoghq.eu', // datadoghq.com should be used instead
+      ],
+    ],
     'lodash/import-scope': ['error', 'method'],
     'max-len': 'off',
     'no-constructor-bind/no-constructor-bind': 'error',

--- a/packages/eslint-config-leboncoin/package.json
+++ b/packages/eslint-config-leboncoin/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-import": "2.20.1",
     "eslint-plugin-jest": "23.8.1",
     "eslint-plugin-json": "2.1.0",
+    "eslint-plugin-literal-blacklist": "0.1.1",
     "eslint-plugin-lodash": "6.0.0",
     "eslint-plugin-no-constructor-bind": "^1.2.7",
     "eslint-plugin-node": "11.0.0",


### PR DESCRIPTION
For more info:
https://github.com/kyaido/eslint-plugin-literal-blacklist

For the moment and to avoid mistakes, the `datadoghq.eu` api host is
blacklisted from string literals. `datadoghq.com` is where you'll find
all your metrics.

Explanation:

Because we are in the EU and every Datadog docs says you should use the
.eu, if you use the EU site, we are tempted to use `api.datadoghq.eu`
instead of `api.datadoghq.com` we use at Leboncoin.