### PR TITLE
update eslint to avoid error when linting

### DIFF
--- a/packages/eslint-config-leboncoin/package.json
+++ b/packages/eslint-config-leboncoin/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "4.16.1",
     "@typescript-eslint/parser": "4.16.1",
-    "eslint": "7.21.0",
+    "eslint": "7.27.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-config-standard": "16.0.2",
     "eslint-plugin-babel": "5.3.1",


### PR DESCRIPTION
```
Oops! Something went wrong! :(
ESLint: 7.21.0

TypeError: Failed to load plugin 'unicorn' declared in 'package.json » eslint-config-leboncoin': babel.loadPartialConfigSync is not a function
```